### PR TITLE
Updated Objectoader.parseObject. Changed the way of iterating over data.children array #11432

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -765,11 +765,10 @@ Object.assign( ObjectLoader.prototype, {
 
 			if ( data.children !== undefined ) {
 
-				for ( var child in data.children ) {
-
-					object.add( this.parseObject( data.children[ child ], geometries, materials ) );
-
-				}
+				var that = this;
+				data.children.forEach(function(index, child){
+					object.add( that.parseObject( data.children[ child ], geometries, materials ) );
+				});
 
 			}
 


### PR DESCRIPTION
Were changed the way of iterating over data.children array in Objectoader.parseObject. Works fine for me. But there is another solution, for example 
`for ( var child in data.children ) {
    if (data.children.hasOwnProperty(child)) {
	object.add( this.parseObject( data.children[ child ], geometries, materials ) );
    }
}`